### PR TITLE
Check for existing segmentations with greater specificity

### DIFF
--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -678,8 +678,16 @@ class CopickRun:
         if uid is None:
             raise ValueError("User ID must be set in the root config or supplied to new_segmentation.")
 
-        if self.get_segmentations(session_id=session_id, user_id=uid):
-            raise ValueError(f"Segmentation by user/tool {uid} already exist in session {session_id}.")
+        if self.get_segmentations(
+            session_id=session_id,
+            user_id=uid,
+            name=name,
+            is_multilabel=is_multilabel,
+            voxel_size=voxel_size,
+        ):
+            raise ValueError(
+                f"Segmentation by user/tool {uid} already exist in session {session_id} with name {name}, voxel size of {voxel_size}, and has a multilabel flag of {is_multilabel}."
+            )
 
         clz, meta_clz = self._segmentation_factory()
 


### PR DESCRIPTION
The previous version would not allow the user to create new segmentations if the user_id and session_id had been used for any segmentations, specifically even if they had different names.