### PR TITLE
Update fsspec requirement to allow writing Zarr via SMBFileSystem

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
 #dynamic = ["version"]
 version = "0.4.0"
 dependencies = [
-    "fsspec",
+    "fsspec>=2024.6.0",
     "pydantic",
     "numpy",
     "trimesh",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -379,6 +379,7 @@ if importlib_util.find_spec("smbclient"):
             "host": "localhost",
             "username": "test.user",
             "password": "password",
+            "auto_mkdir": True,
         }
 
         # Write the config to the local path
@@ -424,6 +425,7 @@ if importlib_util.find_spec("smbclient"):
             "host": "localhost",
             "username": "test.user",
             "password": "password",
+            "auto_mkdir": True,
         }
 
         # Set the overlay root to the sample project

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -16,8 +16,6 @@ with contextlib.suppress(ImportError):
 
 smb_imported = False
 with contextlib.suppress(ImportError):
-    import fsspec.implementations.smb
-
     smb_imported = True
 
 
@@ -986,11 +984,6 @@ def test_tomogram_zarr(test_payload: Dict[str, Any]):
         if isinstance(test_payload["testfs_overlay"], sshfs.SSHFileSystem):
             return
 
-    # TODO: Fix this once new fsspec is released
-    if smb_imported:  # noqa
-        if isinstance(test_payload["testfs_overlay"], fsspec.implementations.smb.SMBFileSystem):
-            return
-
     # Check zarr is readable
     arrays = list(zarr.open(tomogram.zarr(), "r").arrays())
     _, array = arrays[0]
@@ -1029,11 +1022,6 @@ def test_feature_zarr(test_payload: Dict[str, Any]):
     # TODO: Fix this once _pipe_file is implemented
     if sshfs_imported:  # noqa
         if isinstance(test_payload["testfs_overlay"], sshfs.SSHFileSystem):
-            return
-
-    # TODO: Fix this once new fsspec is released
-    if smb_imported:  # noqa
-        if isinstance(test_payload["testfs_overlay"], fsspec.implementations.smb.SMBFileSystem):
             return
 
     # Check zarr is readable


### PR DESCRIPTION
Adds requirement `fsspec>=2024.6.0`. This allows setting the filesystem parameter `auto_mkdir=True` as in the case of LocalFileSystem, which is a requirement for writing Zarr-files with `/`-dimension separators. 

Fixes #21 