### PR TITLE
Update fsspec requirement to allow writing Zarr via SMBFileSystem and sshfs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
 #dynamic = ["version"]
 version = "0.4.0"
 dependencies = [
-    "fsspec",
+    "fsspec>=2024.6.0",
     "pydantic",
     "numpy",
     "trimesh",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,15 +34,15 @@ Issues = "https://github.com/uermel/copick/issues"
 [project.optional-dependencies]
 s3 = ["s3fs"]
 smb = ["smbprotocol"]
-ssh = ["sshfs"]
-all = ["s3fs", "smbprotocol", "sshfs>=2024.4.0"]
-fledgeling = ["pooch", "s3fs", "smbprotocol", "sshfs>=2024.4.0"]
+ssh = ["sshfs>=2024.6.0"]
+all = ["s3fs", "smbprotocol", "sshfs>=2024.6.0"]
+fledgeling = ["pooch", "s3fs", "smbprotocol", "sshfs>=2024.6.0"]
 test = [
     "pytest",
     "pytest-cov",
     "pooch",
     "s3fs",
-    "sshfs>=2024.4.0",
+    "sshfs>=2024.6.0",
     "smbprotocol",
 ]
 dev = [
@@ -128,7 +128,7 @@ test = "pytest {args:tests}"
 
 [tool.hatch.envs.test_extended]
 dependencies = [
-  "pytest", "pooch", "s3fs", "sshfs>=2024.4.0", "smbprotocol"
+  "pytest", "pooch", "s3fs", "sshfs>=2024.6.0", "smbprotocol"
 ]
 
 [tool.hatch.envs.test_extended.scripts]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -379,6 +379,7 @@ if importlib_util.find_spec("smbclient"):
             "host": "localhost",
             "username": "test.user",
             "password": "password",
+            "auto_mkdir": True,
         }
 
         # Write the config to the local path
@@ -424,6 +425,7 @@ if importlib_util.find_spec("smbclient"):
             "host": "localhost",
             "username": "test.user",
             "password": "password",
+            "auto_mkdir": True,
         }
 
         # Set the overlay root to the sample project

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,4 +1,3 @@
-import contextlib
 from typing import Any, Dict
 
 import numpy as np
@@ -7,11 +6,6 @@ import zarr
 from copick.impl.filesystem import CopickRootFSSpec
 from copick.models import CopickPicksFile
 from trimesh.parent import Geometry
-
-smb_imported = False
-with contextlib.suppress(ImportError):
-    smb_imported = True
-
 
 NUMERICAL_PRECISION = 1e-8
 

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -10,8 +10,6 @@ from trimesh.parent import Geometry
 
 sshfs_imported = False
 with contextlib.suppress(ImportError):
-    import sshfs
-
     sshfs_imported = True
 
 smb_imported = False
@@ -566,11 +564,6 @@ def test_run_new_segmentations(test_payload: Dict[str, Any]):
     overlay_fs = test_payload["testfs_overlay"]
     overlay_loc = test_payload["testpath_overlay"]
 
-    # TODO: Fix this once _pipe_file is implemented
-    if sshfs_imported:  # noqa
-        if isinstance(overlay_fs, sshfs.SSHFileSystem):
-            return
-
     only_overlay = True
     static_fs = None
     static_loc = None
@@ -755,11 +748,6 @@ def test_vs_new_tomogram(test_payload: Dict[str, Any]):
     overlay_fs = test_payload["testfs_overlay"]
     overlay_loc = test_payload["testpath_overlay"]
 
-    # TODO: Fix this once _pipe_file is implemented
-    if sshfs_imported:  # noqa
-        if isinstance(overlay_fs, sshfs.SSHFileSystem):
-            return
-
     only_overlay = True
     static_fs = None
     static_loc = None
@@ -892,11 +880,6 @@ def test_tomogram_new_features(test_payload: Dict[str, Any]):
     overlay_fs = test_payload["testfs_overlay"]
     overlay_loc = test_payload["testpath_overlay"]
 
-    # TODO: Fix this once _pipe_file is implemented
-    if sshfs_imported:  # noqa
-        if isinstance(overlay_fs, sshfs.SSHFileSystem):
-            return
-
     only_overlay = True
     static_fs = None
     static_loc = None
@@ -981,11 +964,6 @@ def test_tomogram_zarr(test_payload: Dict[str, Any]):
     vs = copick_run.get_voxel_spacing(10.000)
     tomogram = vs.get_tomogram(tomo_type="denoised")
 
-    # TODO: Fix this once _pipe_file is implemented
-    if sshfs_imported:  # noqa
-        if isinstance(test_payload["testfs_overlay"], sshfs.SSHFileSystem):
-            return
-
     # TODO: Fix this once new fsspec is released
     if smb_imported:  # noqa
         if isinstance(test_payload["testfs_overlay"], fsspec.implementations.smb.SMBFileSystem):
@@ -1025,11 +1003,6 @@ def test_feature_zarr(test_payload: Dict[str, Any]):
     vs = copick_run.get_voxel_spacing(10.000)
     tomogram = vs.get_tomogram(tomo_type="wbp")
     feature = tomogram.get_features(feature_type="sobel")
-
-    # TODO: Fix this once _pipe_file is implemented
-    if sshfs_imported:  # noqa
-        if isinstance(test_payload["testfs_overlay"], sshfs.SSHFileSystem):
-            return
 
     # TODO: Fix this once new fsspec is released
     if smb_imported:  # noqa

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -10,8 +10,6 @@ from trimesh.parent import Geometry
 
 smb_imported = False
 with contextlib.suppress(ImportError):
-    import fsspec.implementations.smb
-
     smb_imported = True
 
 
@@ -960,11 +958,6 @@ def test_tomogram_zarr(test_payload: Dict[str, Any]):
     vs = copick_run.get_voxel_spacing(10.000)
     tomogram = vs.get_tomogram(tomo_type="denoised")
 
-    # TODO: Fix this once new fsspec is released
-    if smb_imported:  # noqa
-        if isinstance(test_payload["testfs_overlay"], fsspec.implementations.smb.SMBFileSystem):
-            return
-
     # Check zarr is readable
     arrays = list(zarr.open(tomogram.zarr(), "r").arrays())
     _, array = arrays[0]
@@ -999,11 +992,6 @@ def test_feature_zarr(test_payload: Dict[str, Any]):
     vs = copick_run.get_voxel_spacing(10.000)
     tomogram = vs.get_tomogram(tomo_type="wbp")
     feature = tomogram.get_features(feature_type="sobel")
-
-    # TODO: Fix this once new fsspec is released
-    if smb_imported:  # noqa
-        if isinstance(test_payload["testfs_overlay"], fsspec.implementations.smb.SMBFileSystem):
-            return
 
     # Check zarr is readable
     arrays = list(zarr.open(feature.zarr(), "r").arrays())

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -8,10 +8,6 @@ from copick.impl.filesystem import CopickRootFSSpec
 from copick.models import CopickPicksFile
 from trimesh.parent import Geometry
 
-sshfs_imported = False
-with contextlib.suppress(ImportError):
-    sshfs_imported = True
-
 smb_imported = False
 with contextlib.suppress(ImportError):
     import fsspec.implementations.smb


### PR DESCRIPTION
1. Adds requirement fsspec>=2024.6.0. This allows setting the filesystem parameter auto_mkdir=True as in the case of LocalFileSystem, which is a requirement for writing Zarr-files with /-dimension separators.
2. Adds requirement sshfs>=2024.6.0. This allows writing Zarr-files via sshfs.

Fixes #20 and #21 

Supercedes #24 