### PR TITLE
Fix README and quick-start example to be consistent with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,5 +102,6 @@ To test with the example dataset:
 
     # Access the data
     group = zarr.open(tomogram.zarr())
-    _, array = group.arrays()[0]
+    arrays = list(group.arrays())
+    _, array = arrays[0]
     ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -94,5 +94,6 @@ To test with the example dataset:
 
     # Access the data
     group = zarr.open(tomogram.zarr())
-    _, array = group.arrays()[0]
+    arrays = list(group.arrays())
+    _, array = arrays[0]
     ```


### PR DESCRIPTION
This fixes the example that is present at the end of the README and the quick-start document. That example doesn't currently work for me because zarr's [`Group.arrays()`](https://zarr.readthedocs.io/en/stable/api/hierarchy.html#zarr.hierarchy.Group.arrays) returns a generator/iterator.

This PR fixes the example to first materialize the arrays to the list, then index the first element. This approach is consistent with the tests.

Alternatively, I considered using `_, array = next(group.arrays())` to be more concise, but decided against it because it's less useful in the real world and may be less readable for the target audience. I also considered using a `tuple` and renaming `array` to `high_res_data`, but decided against both to keep consistency with other parts of the repo (e.g. the tests).